### PR TITLE
Use unarchive module, update syntax for Ansible 2.x

### DIFF
--- a/tasks/configure_odbc.yml
+++ b/tasks/configure_odbc.yml
@@ -1,3 +1,4 @@
+---
 - name: configure ODBC in res_odbc.conf
   ini_file:
    dest: "/etc/asterisk/res_odbc.conf"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,21 +1,15 @@
 ---
 # tasks file for install-asterisk
-- include: pjsip.yml
-
-- name: Remove existing tarball
-  file: "path={{ iasterisk_tarball }} state=absent"
-
-- name: Download asterisk tarball
-  get_url: "url={{ iasterisk_url }} dest={{ iasterisk_tarball }}"
+- include_tasks: pjsip.yml
 
 - name: Remove existing install source dir
   file: "path={{ iasterisk_srcdir }} state=absent"
 
-- name: Create install dir
+- name: Create install source dir
   file: "path={{ iasterisk_srcdir }} state=directory"
 
-- name: Unpack tarball
-  command: "tar -xzf {{ iasterisk_tarball }} -C {{ iasterisk_srcdir }} --strip-components=1"
+- name: Download and extract Asterisk source
+  unarchive: "src={{ iasterisk_url }} dest={{ iasterisk_srcdir }} remote_src=yes extra_opts=--strip-components=1"
 
 - name: Build Asterisk from tarball
   command: "{{ item }} chdir={{ iasterisk_srcdir }}"
@@ -31,13 +25,8 @@
     - make config
     - make samples
 
-- name: Download asterisk sounds (ulaw format)
-  get_url: "url={{ iasterisk_url_sounds }} dest={{ iasterisk_path_soundstarball }}"
-
 - name: Create install dir
   file: "path={{ iasterisk_srcdir }} state=directory"
 
-- name: Unpack sounds
-  command: "tar -xzf {{ iasterisk_path_soundstarball }} -C {{ iasterisk_path_sound }}"
-
-
+- name: Download and extract Asterisk sounds
+  unarchive: "src={{ iasterisk_url_sounds }} dest={{ iasterisk_path_sound }} remote_src=yes extra_opts=--strip-components=1"

--- a/tasks/install_dahdi.yml
+++ b/tasks/install_dahdi.yml
@@ -1,22 +1,16 @@
 ---
 # tasks file for dahdi (runs before installing/compiling asterisk)
 
-- name: Remove existing DAHDI tarball
-  file: "path={{ iasterisk_dahdi_tarball }} state=absent"
-
 - name: Remove existing DAHDI source dir
   file: "path={{ iasterisk_dahdi_srcdir }} state=absent"
 
-- name: Download DAHDI tarball
-  get_url: "url={{ iasterisk_url_dahdi }} dest={{ iasterisk_dahdi_tarball }}"
-
-- name: Create DAHDI install dir
+- name: Create DAHDI source dir
   file: "path={{ iasterisk_dahdi_srcdir }} state=directory"
 
-- name: Unpack DAHDI tarball
-  command: "tar -xzf {{ iasterisk_dahdi_tarball }} -C {{ iasterisk_dahdi_srcdir }} --strip-components=1"
+- name: Download and extract DAHDi source
+  unarchive: "src={{ iasterisk_url_dahdi }} dest={{ iasterisk_dahdi_srcdir }} remote_src=yes extra_opts=--strip-components=1"
 
-- name: "Build DAHDI from tarball IMPORTANT: This may fail if you haven't rebooted after a kernel update!"
+- name: "Build DAHDI from tarball"
   command: "{{ item }} chdir={{ iasterisk_dahdi_srcdir }}"
   with_items:
     - make all

--- a/tasks/install_yum_packages.yml
+++ b/tasks/install_yum_packages.yml
@@ -19,7 +19,7 @@
     - sqlite-devel 
     - openssl-devel 
     - newt-devel 
-    - kernel-devel 
+    - kernel-devel-{{ ansible_kernel }}
     - libuuid-devel 
     - net-snmp-devel
     - bzip2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
-- include: install_odbc.yml
+- include_tasks: install_odbc.yml
   when: iasterisk_odbc_support
-- include: install_yum_packages.yml
-- include: install_dahdi.yml
+- include_tasks: install_yum_packages.yml
+- include_tasks: install_dahdi.yml
   when: iasterisk_dahdi_support
-- include: install.yml
+- include_tasks: install.yml
   when: not skip_install is defined
-- include: configure.yml
+- include_tasks: configure.yml
   when: configure_user is defined
-- include: configure_odbc.yml
+- include_tasks: configure_odbc.yml
   when: iasterisk_odbc_support

--- a/tasks/pjsip.yml
+++ b/tasks/pjsip.yml
@@ -1,21 +1,13 @@
-# RUN mkdir /tmp/pjproject
+---
 
 - name: Make temp pjproject dir
   file: "path=/tmp/pjproject state=directory"
 
-# RUN curl -sf -o /tmp/pjproject.tar.bz2 -L http://www.pjsip.org/release/2.4.5/pjproject-2.4.5.tar.bz2
-
-- name: download pjsip
-  get_url: 
-    url: http://www.pjsip.org/release/2.4.5/pjproject-2.4.5.tar.bz2
-    dest: /tmp/pjproject.tar.bz2
-
-# RUN tar -xjvf /tmp/pjproject.tar.bz2 -C /tmp/pjproject --strip-components=1
-- name: unzip pjsip
-  unarchive: src=/tmp/pjproject.tar.bz2 dest=/tmp/pjproject copy=no
+- name: Download and extract pjSIP source
+  unarchive: "src=http://www.pjsip.org/release/2.4.5/pjproject-2.4.5.tar.bz2 dest=/tmp/pjproject/ remote_src=yes extra_opts=--strip-components=1"
 
 - name: Build pjsip from tarball
-  command: "{{ item }} chdir=/tmp/pjproject/pjproject-2.4.5"
+  command: "{{ item }} chdir=/tmp/pjproject/"
   with_items:
     - ./configure --prefix=/usr --libdir=/usr/lib64 --enable-shared --disable-sound --disable-resample --disable-video --disable-opencore-amr
     - make dep

--- a/test.yml
+++ b/test.yml
@@ -1,7 +1,8 @@
+---
 - hosts: asterisk_machines
   vars_files:
     - vars/main.yml
   tasks:
-    - include: 'tasks/main.yml'
+    - include_tasks: 'tasks/main.yml'
 #      roles:
 #         - { role: username.rolename, x: 42 }

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,11 +2,9 @@
 # vars file for install-asterisk
 asterisk_user: asterisk
 asterisk_group: asterisk
-iasterisk_tarball: /usr/src/iasterisk.tar.gz
 iasterisk_srcdir: /usr/src/iasterisk/
 iasterisk_url: http://downloads.asterisk.org/pub/telephony/asterisk/asterisk-13-current.tar.gz
 iasterisk_url_sounds: http://downloads.asterisk.org/pub/telephony/sounds/asterisk-core-sounds-en-ulaw-current.tar.gz
-iasterisk_path_soundstarball: /usr/src/asterisk_sounds.tar.gz
 iasterisk_path_sound: /var/lib/asterisk/sounds/en
 iasterisk_odbc_support: false
 iasterisk_odbc_pg_database: asterisk
@@ -14,7 +12,5 @@ iasterisk_odbc_pg_server: localhost
 iasterisk_odbc_pg_user: asterisk
 iasterisk_odbc_pg_password: secret
 iasterisk_url_dahdi: http://downloads.asterisk.org/pub/telephony/dahdi-linux-complete/dahdi-linux-complete-current.tar.gz
-iasterisk_dahdi_tarball: /usr/src/dahdi.tar.gz
 iasterisk_dahdi_srcdir: /usr/src/dahdi/
 iasterisk_dahdi_support: false
-


### PR DESCRIPTION
Use unarchive module, update syntax for Ansible 2.x, use {{ ansible_kernel }} for kernel-devel package, various syntax changes. Minimum required Ansible version is now 2.2.