### PR TITLE
Add variable to make pjsip installation optional

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 # defaults file for install-asterisk
+use_pjsip: true

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,6 +1,7 @@
 ---
 # tasks file for install-asterisk
 - include_tasks: pjsip.yml
+  when: use_pjsip
 
 - name: Remove existing install source dir
   file: "path={{ iasterisk_srcdir }} state=absent"


### PR DESCRIPTION
As discussed in #13, I simply added a variable  `use_pjsip` and set it to `true` by default. Some users may still want to use _legacy_ SIP module only and avoid PJSIP.

_Note: this is my first PR on a public project, I followed [this guide](https://help.github.com/articles/creating-a-pull-request/). I hope this is ok._ 