### PR TITLE
Installation of yum packages now only supports CentOS-7

### DIFF
--- a/tasks/install_yum_packages.yml
+++ b/tasks/install_yum_packages.yml
@@ -19,7 +19,7 @@
     - sqlite-devel 
     - openssl-devel 
     - newt-devel 
-    - kernel-devel-{{ ansible_kernel }}
+    - kernel-devel
     - libuuid-devel 
     - net-snmp-devel
     - bzip2


### PR DESCRIPTION
As discussed in #15, @dougbtv is ok with ending support for CentOS 6 so yum package installation is now compatible with CentOS 7 only. 
This means that `kernel-devel-{{ ansible_kernel }}` is now `kernel-devel`.