### PR TITLE
Add task for sounds dir creation

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -29,5 +29,8 @@
 - name: Create install dir
   file: "path={{ iasterisk_srcdir }} state=directory"
 
+- name: Create sounds dir
+  file: "path={{ iasterisk_path_sound }} state=directory"
+
 - name: Download and extract Asterisk sounds
   unarchive: "src={{ iasterisk_url_sounds }} dest={{ iasterisk_path_sound }} remote_src=yes extra_opts=--strip-components=1"


### PR DESCRIPTION
This PR is in response to #17 .
When using a sound directory other than default one (`/var/lib/asterisk/sounds/en`) because a different language is prefered, it has to be created before extracting downloaded Asterisk sounds. Ansible unarchive module does not create directories.

Note: the path for Asterisk sounds directory in this role is set with `iasterisk_path_sound` variable. 